### PR TITLE
update ghc version to work on current Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
 { pkgs ? import <nixpkgs> {}}:
 
-pkgs.haskell.packages.ghc822.callPackage ./twidlk.nix { }
+pkgs.haskell.packages.ghc865.callPackage ./twidlk.nix { }


### PR DESCRIPTION
Resolves https://github.com/edanaher/twidlk/issues/1

(I don't know Nix (or ghc) well enough to know if there's a better way of automatically referring to the latest ghc rather than hard-coding the version in.)